### PR TITLE
Bootstrap check always returns true in case no global scalafmt installed

### DIFF
--- a/scalafmt.sh
+++ b/scalafmt.sh
@@ -64,12 +64,12 @@ function is_server() {
 
 function should_bootstrap() {
 	if is_server; then
-		return $(cmd_not_exists "scalafmt_ng" \
+		(cmd_not_exists "scalafmt_ng" \
 			&& cmd_not_exists "$BOOTSTRAP_DIR/$SCALAFMT_VERSION/scalafmt_ng") \
 			|| version_neq "ng --nailgun-port $SERVER_PORT scalafmt"
 	else
-		return $(cmd_not_exists "scalafmt" || version_neq "scalafmt") \
-			&& $(cmd_not_exists "$BOOTSTRAP_DIR/$SCALAFMT_VERSION/scalafmt" \
+		(cmd_not_exists "scalafmt" || version_neq "scalafmt") \
+			&& (cmd_not_exists "$BOOTSTRAP_DIR/$SCALAFMT_VERSION/scalafmt" \
 				|| version_neq "$BOOTSTRAP_DIR/$SCALAFMT_VERSION/scalafmt")
 	fi
 }


### PR DESCRIPTION
The logic in the should_bootstrap was not working properly. The error that may result from this (at least on my machine) is:

```
/usr/bin/env: bad interpreter: Text file busy
```

This happens because pre-commit runs shell the shell script multiple times in the case many files are being committed. While one instance of the shell script is bootstrapping with coursier another is trying to run scalafmt at the same time. However running a file that is open for writing results in the aforementioned error.